### PR TITLE
core: host matching fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,11 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of JSONResolver.
-# Copyright (C) 2015 CERN.
+# This file is part of jsonresolver
+# Copyright (C) 2015, 2016 CERN.
 #
-# JSONResolver is free software; you can redistribute it
-# and/or modify it under the terms of the GNU General Public License as
-# published by the Free Software Foundation; either version 2 of the
-# License, or (at your option) any later version.
-#
-# JSONResolver is distributed in the hope that it will be
-# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with JSONResolver; if not, write to the
-# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
-# MA 02111-1307, USA.
-#
-# In applying this license, CERN does not
-# waive the privileges and immunities granted to it by virtue of its status
-# as an Intergovernmental Organization or submit itself to any jurisdiction.
-
+# jsonresolver is free software; you can redistribute it and/or modify
+# it under the terms of the Revised BSD License; see LICENSE file for
+# more details.
 
 notifications:
   email: false

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,6 +1,6 @@
 ..
     This file is part of jsonresolver
-    Copyright (C) 2015 CERN.
+    Copyright (C) 2015, 2016 CERN.
 
     jsonresolver is free software; you can redistribute it and/or modify
     it under the terms of the Revised BSD License; see LICENSE file for
@@ -13,3 +13,4 @@ JSON data resolver with support for plugins.
 
 - Jiri Kuncar <jiri.kuncar@cern.ch>
 - Krzysztof Nowak <k.nowak@cern.ch>
+- Lars Holm Nielsen <lars.holm.nielsen@cern.ch>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,26 +1,11 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of JSONResolver.
-# Copyright (C) 2015 CERN.
+# This file is part of jsonresolver
+# Copyright (C) 2015, 2016 CERN.
 #
-# JSONResolver is free software; you can redistribute it
-# and/or modify it under the terms of the GNU General Public License as
-# published by the Free Software Foundation; either version 2 of the
-# License, or (at your option) any later version.
-#
-# JSONResolver is distributed in the hope that it will be
-# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with JSONResolver; if not, write to the
-# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
-# MA 02111-1307, USA.
-#
-# In applying this license, CERN does not
-# waive the privileges and immunities granted to it by virtue of its status
-# as an Intergovernmental Organization or submit itself to any jurisdiction.
+# jsonresolver is free software; you can redistribute it and/or modify
+# it under the terms of the Revised BSD License; see LICENSE file for
+# more details.
 
 from __future__ import print_function
 

--- a/jsonresolver/core.py
+++ b/jsonresolver/core.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of jsonresolver
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # jsonresolver is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
@@ -37,7 +37,7 @@ class JSONResolver(object):
 
     def _build_url_map(self):
         """Build an URL map from registered plugins."""
-        self.url_map = Map()
+        self.url_map = Map(host_matching=True)
         self.pm.hook.jsonresolver_loader(url_map=self.url_map)
 
     def resolve(self, url):
@@ -45,5 +45,5 @@ class JSONResolver(object):
         if self.url_map is None:
             self._build_url_map()
         parts = urlsplit(url)
-        loader, args = self.url_map.bind(parts.hostname).match(parts.path)
+        loader, args = self.url_map.bind(parts.netloc).match(parts.path)
         return loader(**args)

--- a/jsonresolver/version.py
+++ b/jsonresolver/version.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of jsonresolver
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # jsonresolver is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,29 +1,14 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of JSONResolver.
-# Copyright (C) 2015 CERN.
+# This file is part of jsonresolver
+# Copyright (C) 2015, 2016 CERN.
 #
-# JSONResolver is free software; you can redistribute it
-# and/or modify it under the terms of the GNU General Public License as
-# published by the Free Software Foundation; either version 2 of the
-# License, or (at your option) any later version.
-#
-# JSONResolver is distributed in the hope that it will be
-# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with JSONResolver; if not, write to the
-# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
-# MA 02111-1307, USA.
-#
-# In applying this license, CERN does not
-# waive the privileges and immunities granted to it by virtue of its status
-# as an Intergovernmental Organization or submit itself to any jurisdiction.
+# jsonresolver is free software; you can redistribute it and/or modify
+# it under the terms of the Revised BSD License; see LICENSE file for
+# more details.
 
 
-pep257 jsonresolver && \
+pydocstyle jsonresolver && \
 isort -rc -c -df **/*.py && \
 check-manifest --ignore ".travis-*" && \
 sphinx-build -qnNW docs docs/_build/html && \

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of JSONResolver.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # JSONResolver is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -22,6 +22,8 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
+[aliases]
+test = pytest
 
 [build_sphinx]
 source-dir = docs/

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of jsonresolver
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # jsonresolver is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
@@ -11,10 +11,8 @@
 
 import os
 import re
-import sys
 
 from setuptools import find_packages, setup
-from setuptools.command.test import test as TestCommand
 
 readme = open('README.rst').read()
 history = open('CHANGES.rst').read()
@@ -23,7 +21,8 @@ tests_require = [
     'check-manifest>=0.25',
     'coverage>=4.0',
     'isort>=4.2.2',
-    'pep257>=0.7.0',
+    'mock>=1.3.0',
+    'pydocstyle>=1.0.0',
     'pytest-cache>=1.0',
     'pytest-cov>=1.8.0',
     'pytest-pep8>=1.0.6',
@@ -48,7 +47,9 @@ extras_require['all'] = []
 for reqs in extras_require.values():
     extras_require['all'].extend(reqs)
 
-setup_requires = []
+setup_requires = [
+    'pytest-runner>=2.7.0',
+]
 
 install_requires = [
     'six>=1.8.0',
@@ -57,40 +58,6 @@ install_requires = [
 ]
 
 packages = find_packages()
-
-
-class PyTest(TestCommand):
-    """PyTest Test."""
-
-    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
-
-    def initialize_options(self):
-        """Init pytest."""
-        TestCommand.initialize_options(self)
-        self.pytest_args = []
-        try:
-            from ConfigParser import ConfigParser
-        except ImportError:
-            from configparser import ConfigParser
-        config = ConfigParser()
-        config.read('pytest.ini')
-        self.pytest_args = config.get('pytest', 'addopts').split(' ')
-
-    def finalize_options(self):
-        """Finalize pytest."""
-        TestCommand.finalize_options(self)
-        if hasattr(self, '_test_args'):
-            self.test_suite = ''
-        else:
-            self.test_args = []
-            self.test_suite = True
-
-    def run_tests(self):
-        """Run tests."""
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-        errno = pytest.main(self.pytest_args)
-        sys.exit(errno)
 
 
 # Get the version string. Cannot be done with import!
@@ -118,7 +85,6 @@ setup(
     install_requires=install_requires,
     setup_requires=setup_requires,
     tests_require=tests_require,
-    cmdclass={'test': PyTest},
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',

--- a/tests/demo/hosts.py
+++ b/tests/demo/hosts.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of jsonresolver
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2016 CERN.
 #
 # jsonresolver is free software; you can redistribute it and/or
 # modify it under the terms of the Revised BSD License; see LICENSE
@@ -12,7 +12,7 @@
 import jsonresolver
 
 
-@jsonresolver.route('/test', host='localhost:4000')
-def simple():
+@jsonresolver.route('/test', host='inveniosoftware.org')
+def sameroute_as_simple():
     """Return a fixed JSON."""
-    return {'test': 'test'}
+    return {'test': 'inveniosoftware.org'}

--- a/tests/demo/internals.py
+++ b/tests/demo/internals.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of jsonresolver
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # jsonresolver is free software; you can redistribute it and/or
 # modify it under the terms of the Revised BSD License; see LICENSE
@@ -24,5 +24,5 @@ def jsonresolver_loader(url_map):
         ).json
 
     url_map.add(
-        Rule('/record/<recid>', endpoint=endpoint, host='http://cds.cern.ch')
+        Rule('/record/<recid>', endpoint=endpoint, host='cds.cern.ch')
     )

--- a/tests/demo/raising.py
+++ b/tests/demo/raising.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of jsonresolver
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # jsonresolver is free software; you can redistribute it and/or
 # modify it under the terms of the Revised BSD License; see LICENSE
@@ -16,7 +16,7 @@ class EndpointCallDetected(Exception):
     """Raise this ``exception`` to detect when a plugin is called in test."""
 
 
-@jsonresolver.route('/test', host='http://localhost:4000')
+@jsonresolver.route('/test', host='localhost:4000')
 def raising():
     """Raise an exception."""
     raise EndpointCallDetected

--- a/tests/demo/schema.py
+++ b/tests/demo/schema.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of jsonresolver
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # jsonresolver is free software; you can redistribute it and/or
 # modify it under the terms of the Revised BSD License; see LICENSE
@@ -12,7 +12,7 @@
 import jsonresolver
 
 
-@jsonresolver.route('/schema/<path:name>', host='http://localhost:4000')
+@jsonresolver.route('/schema/<path:name>', host='localhost:4000')
 def schema(name):
     """Return a fixed JSON ``schema``."""
     assert name == 'authors.json'

--- a/tests/test_jsonref.py
+++ b/tests/test_jsonref.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of jsonresolver
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # jsonresolver is free software; you can redistribute it and/or
 # modify it under the terms of the Revised BSD License; see LICENSE
@@ -53,3 +53,18 @@ def test_missing_route():
     data = JsonRef.replace_refs(example_schema, loader=loader)
     with pytest.raises(JsonRefError):
         data['properties']['authors']['type']
+
+
+def test_same_route_different_hosts():
+    """Test orignal resolver."""
+    example = {
+        'host1': {'$ref': 'http://localhost:4000/test'},
+        'host2': {'$ref': 'http://inveniosoftware.org/test'},
+    }
+
+    json_resolver = JSONResolver(plugins=['demo.simple', 'demo.hosts'])
+    loader_cls = json_loader_factory(json_resolver)
+    loader = loader_cls()
+    data = JsonRef.replace_refs(example, loader=loader)
+    assert data['host1']['test'] == 'test'
+    assert data['host2']['test'] == 'inveniosoftware.org'


### PR DESCRIPTION
- FIX Fixes issues with the hostname not being matched resulting in the
  same route on two hosts not to work.
- INCOMPATIBLE Changes resolving to be based on hostname without
  http:// prefix.
- Fixes wrong license headers.

Signed-off-by: Lars Holm Nielsen lars.holm.nielsen@cern.ch
