### PR TITLE
global: update python dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@
 notifications:
   email: false
 
-sudo: false
-
 language: python
 
 cache:
@@ -23,10 +21,9 @@ env:
   - REQUIREMENTS=devel
 
 python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
   - "3.5"
+  - "3.6"
+  - "3.7"
 
 before_install:
   - "travis_retry pip install --upgrade pip setuptools py"
@@ -51,7 +48,8 @@ deploy:
   password:
     secure: xS0SP3ODUsZuz+Gz14fzQPLPBGlCYUChQa1idShx/ztfVdl0GKDTfzclmHooRHIeIt9gpz3zLGQ6phyXe+TQYzqITTI6kfp/Lx42jF2e/bY0miVw5g1sTSEipcvuVqJiE4UmPolhvU/j4Kzq4PUus3gURpzypIXqEJznUPW2ypfyBsVVBL77gUZ9kFIeMr+5QUQ0Ss+z//gLuRXoZZJckX4f5Du83NE+e5w/ZuzArFk1EOzH1637O/ZZr885XPAiOcBZRIJ8Xoj/HSetNMNRW5vXfYRkJKIB10rnV6QsaF5/PJyxw+6vLfBPhTwYVkIKHc0rQkbL2uoAYym+fHG3aIrKm0EBaFZODIRsyPbTOAFaO9r1baCi/Hgrwvon8kEQwlq2TRsGzGZ4BBAk1NYur9gTc3W2a5S1Ax2hpzGO5P4KXhelWQ0KHf3oALaG3zPptJu7DLXSBgDpJbpKGN7edDclsZF825kQwvNu/4g6QLCtjqtu2IDfdVTl4gd4e15WfpSD+5znb26QKbaM4pGn6pFHVlQzA5TXaM9WdSxmu3DxKbvDG6X1vp0tl1/qiOIyCuz0kBxCSrqnuAeFfPvVbSJyoiRP26PrivusEA1ghDZ7+u7cGZsAamCG2197PwFAE5g6O7jCBKBclES2dy6BIabTVR7z/Wr5vkCMgXwGzo4=
   distributions: "sdist bdist_wheel"
+  skip_existing: true
   on:
-    python: "2.7"
+    python: "3.6"
     repo: inveniosoftware/jsonresolver
     tags: true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,14 @@
 Changes
 =======
 
+Version 0.3.0 (released 2020-03-12)
+-----------------------------------
+
+- Drops support for Python 2.7
+- Updates testing method
+- Updates python dependencies
+
+
 Version 0.2.1 (released 2016-04-15)
 -----------------------------------
 

--- a/jsonresolver/contrib/jsonref.py
+++ b/jsonresolver/contrib/jsonref.py
@@ -14,18 +14,18 @@ Use ``json_loader_factory`` if you want to take advantage of default
 by your ``JSONResolver`` instance.
 
 Example:
-
 .. code-block:: python
 
    >>> from jsonref import JsonRef
    >>> from jsonresolver import JSONResolver
    >>> from jsonresolver.contrib.jsonref import json_loader_factory
    >>> schema = {'$ref': 'http://localhost:4000/schema/authors.json#'}
-   >>> json_resolver = JSONResolver(plugins=['demo.schema'])
+   >>> json_resolver = JSONResolver(plugins=['tests.demo.schema'])
    >>> loader_cls = json_loader_factory(json_resolver)
    >>> loader = loader_cls(cache_results=False)
    >>> dict(JsonRef.replace_refs(schema, loader=loader))
    {'type': 'array'}
+
    # if you do not want default fallback:
    >>> dict(JsonRef.replace_refs(schema, loader=json_resolver.resolve))
    {'type': 'array'}

--- a/jsonresolver/contrib/jsonschema.py
+++ b/jsonresolver/contrib/jsonschema.py
@@ -14,18 +14,17 @@ implementation of remote URL resolver. The resolver is used to retrieve JSON
 object based on registered plugins.
 
 Example:
-
 .. code-block:: python
 
    >>> from jsonschema import validate
    >>> from jsonresolver import JSONResolver
    >>> from jsonresolver.contrib.jsonschema import ref_resolver_factory
    >>> schema = {'$ref': 'http://localhost:4000/schema/authors.json#'}
-   >>> json_resolver = JSONResolver(plugins=['demo.schema'])
+   >>> json_resolver = JSONResolver(plugins=['tests.demo.schema'])
    >>> resolver_cls = ref_resolver_factory(json_resolver)
    >>> resolver = resolver_cls.from_schema(schema)
    >>> validate(['foo', 'bar'], schema, resolver=resolver)
-   None
+
 
 """
 

--- a/jsonresolver/version.py
+++ b/jsonresolver/version.py
@@ -16,4 +16,4 @@ This file is imported by ``jsonresolver.__init__``, and parsed by
 # Do not change the format of this next line. Doing so risks breaking
 # setup.py and docs/conf.py
 
-__version__ = "0.2.2.dev20160415"
+__version__ = "0.3.0.dev20200310"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -12,5 +12,5 @@ pydocstyle jsonresolver && \
 isort -rc -c -df **/*.py && \
 check-manifest --ignore ".travis-*" && \
 sphinx-build -qnNW docs docs/_build/html && \
-python setup.py test && \
+python tests/setup.py test && \
 sphinx-build -qnNW -b doctest docs docs/_build/doctest

--- a/setup.py
+++ b/setup.py
@@ -24,15 +24,15 @@ tests_require = [
     'mock>=1.3.0',
     'pydocstyle>=1.0.0',
     'pytest-cache>=1.0',
-    'pytest-cov>=1.8.0',
+    'pytest-cov>=2.8.1',
     'pytest-pep8>=1.0.6',
-    'pytest>=2.8.0',
+    'pytest>=3.6.0',
     'requests>=2.7.0',
 ]
 
 extras_require = {
     'docs': [
-        "Sphinx>=1.4.2",
+        "Sphinx>=1.5.1",
     ],
     'jsonref': [
         'jsonref>=0.1',
@@ -52,9 +52,9 @@ setup_requires = [
 ]
 
 install_requires = [
-    'six>=1.8.0',
-    'pluggy>=0.3.0,<1.0',
-    'werkzeug>=0.10.4',
+    'six>=1.12.0',
+    'pluggy>=0.10.0,<1.0',
+    'werkzeug>=1.0.0',
 ]
 
 packages = find_packages()

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -1,0 +1,64 @@
+import os
+
+from setuptools import setup
+
+current_dir = os.getcwd()
+
+tests_require = [
+    'check-manifest>=0.25',
+    'coverage>=4.0',
+    'isort>=4.2.2',
+    'mock>=1.3.0',
+    'pydocstyle>=1.0.0',
+    'pytest-cache>=1.0',
+    'pytest-cov>=2.8.1',
+    'pytest-pep8>=1.0.6',
+    'pytest>=3.0.0',
+    'requests>=2.7.0',
+]
+
+extras_require = {
+    'docs': [
+        "Sphinx>=1.5.1",
+    ],
+    'jsonref': [
+        'jsonref>=0.1',
+    ],
+    'jsonschema': [
+        'jsonschema>=2.5.1',
+    ],
+    'tests': tests_require,
+}
+
+extras_require['all'] = []
+for reqs in extras_require.values():
+    extras_require['all'].extend(reqs)
+
+setup_requires = [
+    'pytest-runner>=2.7.0',
+]
+
+install_requires = [
+    'six>=1.12.0',
+    'pluggy>=0.10.0,<1.0',
+    'werkzeug>=1.0.0',
+]
+
+setup(
+    name="demo",
+    packages=['demo'],
+    package_dir={'demo': current_dir},
+    install_requires=install_requires,
+    extras_require=extras_require,
+    setup_requires=setup_requires,
+    # the following makes a plugin available to pytest
+    entry_points={
+        'espresso': ['demo.simple = demo.simple'],
+        'raising': ['demo.raising = demo.raising'],
+        'raising_hook': ['demo.raising_hook = demo.raising_hook'],
+        'someotherstuff': [],
+        'doubletrouble': ['demo.simple = demo.simple',
+                          'demo.simple2 = demo.simple'],
+        'importfail': ['importfail = test.importfail'],
+    }
+)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -11,48 +11,13 @@
 
 from __future__ import absolute_import
 
-import importlib
-
 import pytest
 from demo.raising import EndpointCallDetected
 from demo.raising_hook import HookRegistrationDetected
-from mock import patch
-from pkg_resources import EntryPoint
 
 from jsonresolver import JSONResolver
 
 
-class MockEntryPoint(EntryPoint):
-    """EntryPoint mock."""
-
-    def load(self):
-        """Load module from the mocked entry point."""
-        if self.name == 'importfail':
-            raise ImportError()
-        else:
-            return importlib.import_module(self.name)
-
-
-def _mock_entry_points(name):
-    """Mock the entry points."""
-    data = {
-        'espresso': [MockEntryPoint('demo.simple', 'demo.simple')],
-        'raising': [MockEntryPoint('demo.raising', 'demo.raising')],
-        'raising_hook': [MockEntryPoint('demo.raising_hook',
-                                        'demo.raising_hook')],
-        'someotherstuff': [],
-        'doubletrouble': [MockEntryPoint('demo.simple', 'demo.simple'),
-                          MockEntryPoint('demo.simple', 'demo.simple')],
-        'importfail': [MockEntryPoint('importfail',
-                                      'test.importfail')],
-    }
-    names = data.keys() if name is None else [name]
-    for key in names:
-        for entry_point in data[key]:
-            yield entry_point
-
-
-@patch('pkg_resources.iter_entry_points', _mock_entry_points)
 def test_entry_point_group():
     """Test the entry point group loading."""
     resolver = JSONResolver(entry_point_group='espresso')
@@ -65,7 +30,6 @@ def test_plugins():
     assert resolver.resolve('http://localhost:4000/test') == {'test': 'test'}
 
 
-@patch('pkg_resources.iter_entry_points', _mock_entry_points)
 def test_plugin_lazy_execution():
     """Test the lazy evaluation of loaded plugin."""
     # Plugin code should be called (i.e. raise exception) on resolve method
@@ -81,7 +45,6 @@ def test_plugin_lazy_execution():
     assert exc_info.type is EndpointCallDetected
 
 
-@patch('pkg_resources.iter_entry_points', _mock_entry_points)
 def test_plugin_lazy_execution_hooks():
     """Test the lazy evaluation of loaded plugin through hooks."""
     # Plugin code should be called (i.e. raise exception) on resolve method


### PR DESCRIPTION
* drop support for python 2.7
* fix tests to follow the changes in registering entry points
  (from `pkg_resources.iter_entry_points` to `importlib_metadata`
* closes #19 
