### PR TITLE
fix: add jsonschema-specifications to install_requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ zip_safe = False
 install_requires =
     pluggy>=1.0,<2
     werkzeug>=1.0.0
+    jsonschema-specifications
 
 [options.extras_require]
 tests =


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

A dependency to jsonschema-specifications was added https://github.com/inveniosoftware/jsonresolver/commit/ff7ddaa5b900dc9d228248f9c783732041ba7f9b, but it wasn't added to install-requires so folks who don't have it in their environment will experience an error. 


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).



**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
